### PR TITLE
CCS-4407: Use the new redis server in git2pantheon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ pip3 install .
 5. Set and export the following environment variables  
    a. PANTHEON_SERVER  
    b. UPLOADER_PASSWORD  
-   c. UPLOADER_USER
+   c. UPLOADER_USER  
+   d. REDIS_SERVICE
    
 
 6. Set the app name for flask run command

--- a/git2pantheon/messaging.py
+++ b/git2pantheon/messaging.py
@@ -1,2 +1,19 @@
 import redis
-broker = redis.Redis(decode_responses=True)
+import os
+import logging
+
+from redis.exceptions import RedisError
+
+
+def initialize_broker():
+    if 'REDIS_SERVICE' not in os.environ:
+        logging.error('REDIS_SERVICE is not set in environment variables. Status API would be impacted')
+    redis_conn = redis.Redis(host=os.getenv('REDIS_SERVICE'), decode_responses=True)
+    try:
+        redis_conn.ping()
+    except RedisError as redis_error:
+        logging.error('Could not connect to Redis instance. Status API would be impacted')
+    return redis_conn
+
+
+broker = initialize_broker()

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setup(
         'marshmallow>=3.9.1',
         'gitpython>=3.1.11',
         'gunicorn',
-        'pantheon-uploader @ git+https://github.com/redhataccess/pantheon-uploader.git@master#egg=pantheon-uploader-0.2'
+        'pantheon-uploader @ git+https://github.com/aprajshekhar/pantheon-uploader.git@ap_CCS-4407_redis_ser#egg=pantheon-uploader-0.2'
     ],
-    dependency_links=['https://github.com/redhataccess/pantheon-uploader/tarball/master#egg=pantheon-uploader'],
+    dependency_links=['https://github.com/aprajshekhar/pantheon-uploader/tarball/ap_CCS-4407_redis_ser#egg=pantheon-uploader'],
     entry_points=entry_points,
     package_data={'': package_data}
 )


### PR DESCRIPTION
This PR adds:

1. Functionality to use a separate (non localhost) host for redis.
2. Check whether host is responding. If not, the log appropriately.
3. Does not stop the application if host is not available.
**Please ignore changes in setup.py as they would be reverted once QA verification is done**